### PR TITLE
feat: overhead line support offset and rotation adjustment

### DIFF
--- a/resources/generated/systems/overhead_line/lang/en_us.json
+++ b/resources/generated/systems/overhead_line/lang/en_us.json
@@ -20,6 +20,8 @@
 "msg.kuayue.overhead_line_target_set": "Current catenary frame selected, please click another catenary frame to establish connection",
 "msg.kuayue.overhead_line_same_support": "Cannot connect to the same catenary frame",
 "msg.kuayue.overhead_line_incompatible_block": "Incompatible block",
+"msg.kuayue.overhead_line_max_connections_reached": "Maximum number of connections reached",
+"msg.kuayue.overhead_line_duplicate_connection": "Cannot connect to the same two catenary frames",
 "block.kuayue.overhead_pillar_concrete": "Equidistant Round Concrete Pillar",
 "block.kuayue.overhead_pillar_concrete_truss_a": "Equidistant Round Pillar Truss Type A",
 "block.kuayue.overhead_pillar_concrete_truss_b": "Equidistant Round Pillar Truss Type B",

--- a/resources/generated/systems/overhead_line/lang/zh_cn.json
+++ b/resources/generated/systems/overhead_line/lang/zh_cn.json
@@ -20,6 +20,8 @@
   "msg.kuayue.overhead_line_target_set": "已选中当前接触网架，请点击另一接触网架建立连接",
   "msg.kuayue.overhead_line_same_support": "不能连接同一个接触网架",
   "msg.kuayue.overhead_line_incompatible_block": "不支持的方块",
+  "msg.kuayue.overhead_line_max_connections_reached": "已达到最大连接数",
+  "msg.kuayue.overhead_line_duplicate_connection": "不能重复连接两个接触网架",
   "block.kuayue.overhead_pillar_concrete": "等距圆支柱 ",
   "block.kuayue.overhead_pillar_concrete_truss_a": "等距圆支柱连接架A型",
   "block.kuayue.overhead_pillar_concrete_truss_b": "等距圆支柱连接架B型",

--- a/src/main/java/willow/train/kuayue/initial/AllPackets.java
+++ b/src/main/java/willow/train/kuayue/initial/AllPackets.java
@@ -6,6 +6,7 @@ import willow.train.kuayue.network.c2s.tech_tree.*;
 import willow.train.kuayue.network.s2c.*;
 import willow.train.kuayue.network.s2c.tech_tree.*;
 import willow.train.kuayue.systems.device.track.train_station.packet.C2STrainStationInfoUpdatePacket;
+import willow.train.kuayue.systems.overhead_line.packet.C2SOverheadLineSupportAdjustPacket;
 
 public class AllPackets {
     public static final String KUAYUE_NETWORK_VERSION = "v1.0.0";
@@ -18,6 +19,7 @@ public class AllPackets {
             .loadPacket(DiscardChangeC2SPacket.class, DiscardChangeC2SPacket::new)
             .loadPacket(NbtC2SPacket.class, NbtC2SPacket::new)
             .loadPacket(C2STrainStationInfoUpdatePacket.class, C2STrainStationInfoUpdatePacket::new)
+            .loadPacket(C2SOverheadLineSupportAdjustPacket.class, C2SOverheadLineSupportAdjustPacket::new)
             .submit(AllElements.testRegistry);
 
     public static final ChannelReg TECH_TREE_CHANNEL = new ChannelReg("kuayue_tech_tree_channel")

--- a/src/main/java/willow/train/kuayue/initial/panel/I3DPanel.java
+++ b/src/main/java/willow/train/kuayue/initial/panel/I3DPanel.java
@@ -181,7 +181,7 @@ public class I3DPanel {
                             "hxd3d/pantograph/hxd3d_panto_pull_rod",
                             "hxd3d/pantograph/hxd3d_panto_small_arm",
                             "hxd3d/pantograph/hxd3d_panto_bow_head",
-                            1.5f, 60
+                            1.5f, 50
                             ))
                     .material(Material.METAL).materialColor(MaterialColor.COLOR_BLACK)
                     .addProperty(properties -> properties.strength(1.5f, 3f))

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/OverheadLineSystem.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/OverheadLineSystem.java
@@ -8,6 +8,7 @@ import willow.train.kuayue.systems.overhead_line.block.support.OverheadLineSuppo
 import willow.train.kuayue.systems.overhead_line.block.support.OverheadLineSupportBlockEntity;
 import willow.train.kuayue.systems.overhead_line.block.support.OverheadSupportBlockRenderer;
 import willow.train.kuayue.systems.overhead_line.block.support.variants.AllOverheadLineSupportModels;
+import willow.train.kuayue.systems.overhead_line.client.AllOverheadLineMenuScreens;
 import willow.train.kuayue.systems.overhead_line.save.OverheadLineSaved;
 import willow.train.kuayue.systems.overhead_line.test.OverheadLineSupportBlockTest;
 import willow.train.kuayue.systems.overhead_line.wire.AllWires;
@@ -26,6 +27,7 @@ public class OverheadLineSystem {
         AllOverheadLineSupportBlocks.invoke();
         AllWires.invoke();
         AllOverheadLineDecoratingBlocks.invoke();
+        AllOverheadLineMenuScreens.invoke();
     }
 
     public OverheadLineSaved savedData = new OverheadLineSaved();

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/line/OverheadLineRendererSystem.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/line/OverheadLineRendererSystem.java
@@ -4,13 +4,11 @@ import kasuga.lib.core.client.model.anim_model.AnimModel;
 import kasuga.lib.core.util.data_type.Pair;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
-import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
@@ -21,11 +19,8 @@ import willow.train.kuayue.systems.overhead_line.block.support.OverheadLineSuppo
 import willow.train.kuayue.systems.overhead_line.render.CachedCurveRenderer;
 import willow.train.kuayue.systems.overhead_line.render.RenderCurve;
 import willow.train.kuayue.systems.overhead_line.types.OverheadLineType;
-import willow.train.kuayue.systems.overhead_line.wire.OverheadLineRendererUtils;
 
 import java.util.HashMap;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static net.minecraftforge.client.event.RenderLevelStageEvent.Stage.*;
@@ -107,7 +102,7 @@ public class OverheadLineRendererSystem {
 
         RenderCurve curve = renderer.getRenderCurveFor(
                 blockEntity.getLevel(),
-                blockEntity.getConnectionPointByIndex(connection.connectionIndex()),
+                blockEntity.getConnectionPointByIndex(connection.connectionIndex(), connection.type()),
                 new Vec3(connection.toPosition())
         );
         OVERHEAD_LINES.put(locator, new Rendering(curve, renderer.getModel(), curve.getMatrix().getBoundingBox()));

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/AllOverheadLineSupportBlocks.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/AllOverheadLineSupportBlocks.java
@@ -15,6 +15,20 @@ public class AllOverheadLineSupportBlocks {
                     .withRenderer(()->OverheadSupportBlockRenderer::new)
                     .submit(AllElements.testRegistry);
 
+    public static BlockEntityReg<OverheadLineSupportBBlockEntity> OVERHEAD_LINE_SUPPORT_B_BLOCK_ENTITY =
+            new BlockEntityReg<OverheadLineSupportBBlockEntity>("overhead_line_support_b_block_entity")
+                    .blockEntityType(OverheadLineSupportBBlockEntity::new)
+                    .blockPredicates((r, i)->i instanceof OverheadLineSupportBlock)
+                    .withRenderer(()->OverheadSupportBlockRenderer::new)
+                    .submit(AllElements.testRegistry);
+
+    public static BlockEntityReg<OverheadLineSupportB2BlockEntity> OVERHEAD_LINE_SUPPORT_B2_BLOCK_ENTITY =
+            new BlockEntityReg<OverheadLineSupportB2BlockEntity>("overhead_line_support_b2_block_entity")
+                    .blockEntityType(OverheadLineSupportB2BlockEntity::new)
+                    .blockPredicates((r, i)->i instanceof OverheadLineSupportBlock)
+                    .withRenderer(()->OverheadSupportBlockRenderer::new)
+                    .submit(AllElements.testRegistry);
+
     public static OverheadLineSupportBlockReg<OverheadLineSupportBlock<OverheadLineSupportBlockEntity>,OverheadLineSupportBlockEntity> OVERHEAD_LINE_SUPPORT_A1 =
             new OverheadLineSupportBlockReg<>("overhead_line_support_a1")
                     .blockType(NormalOverheadLineSupportBlock::new)
@@ -28,6 +42,7 @@ public class AllOverheadLineSupportBlocks {
                             AllWires.OVERHEAD_LINE_WIRE,
                             AllWires.ELECTRONIC_WIRE
                     )
+                    .maxConnections(8)
                     .submit(AllElements.testRegistry);
 
     public static OverheadLineSupportBlockReg<OverheadLineSupportBlock<OverheadLineSupportBlockEntity>,OverheadLineSupportBlockEntity> OVERHEAD_LINE_SUPPORT_A2 =
@@ -43,36 +58,41 @@ public class AllOverheadLineSupportBlocks {
                             AllWires.OVERHEAD_LINE_WIRE,
                             AllWires.ELECTRONIC_WIRE
                     )
+                    .maxConnections(8)
                     .submit(AllElements.testRegistry);
 
-    public static OverheadLineSupportBlockReg<OverheadLineSupportBlock<OverheadLineSupportBlockEntity>,OverheadLineSupportBlockEntity> OVERHEAD_LINE_SUPPORT_B =
-            new OverheadLineSupportBlockReg<>("overhead_line_support_b")
-                    .blockType(NormalOverheadLineSupportBlock::new)
+    public static OverheadLineSupportBlockReg<OverheadLineSupportBBlock,OverheadLineSupportBBlockEntity> OVERHEAD_LINE_SUPPORT_B =
+            new OverheadLineSupportBlockReg<OverheadLineSupportBBlock,OverheadLineSupportBBlockEntity>("overhead_line_support_b")
+                    .blockType(OverheadLineSupportBBlock::new)
+                    .withBlockEntity(OVERHEAD_LINE_SUPPORT_B_BLOCK_ENTITY)
                     .defaultBlockItem()
                     .tabTo(AllElements.neoKuayueGridTab)
                     .withRenderer(()-> OverheadLineSupportBRenderer.B1Renderer::new)
                     .connectionPoints(
-                            new Vec3(1.55, .125, 0)
+                            new Vec3(1.55, -0.3, 0)
                     )
                     .addAllowedWireType(
                             AllWires.OVERHEAD_LINE_WIRE,
                             AllWires.ELECTRONIC_WIRE
                     )
+                    .maxConnections(8)
                     .submit(AllElements.testRegistry);
 
-    public static OverheadLineSupportBlockReg<OverheadLineSupportBlock<OverheadLineSupportBlockEntity>,OverheadLineSupportBlockEntity> OVERHEAD_LINE_SUPPORT_B2 =
-            new OverheadLineSupportBlockReg<>("overhead_line_support_b2")
-                    .blockType(NormalOverheadLineSupportBlock::new)
+    public static OverheadLineSupportBlockReg<OverheadLineSupportB2Block,OverheadLineSupportB2BlockEntity> OVERHEAD_LINE_SUPPORT_B2 =
+            new OverheadLineSupportBlockReg<OverheadLineSupportB2Block,OverheadLineSupportB2BlockEntity>("overhead_line_support_b2")
+                    .blockType(OverheadLineSupportB2Block::new)
+                    .withBlockEntity(OVERHEAD_LINE_SUPPORT_B2_BLOCK_ENTITY)
                     .defaultBlockItem()
                     .tabTo(AllElements.neoKuayueGridTab)
                     .withRenderer(()-> OverheadLineSupportBRenderer.B2Renderer::new)
                     .connectionPoints(
-                            new Vec3(2.25, .125, 0)
+                            new Vec3(2.25, -0.6, 0)
                     )
                     .addAllowedWireType(
                             AllWires.OVERHEAD_LINE_WIRE,
                             AllWires.ELECTRONIC_WIRE
                     )
+                    .maxConnections(8)
                     .submit(AllElements.testRegistry);
 
     public static OverheadLineSupportBlockReg<OverheadLineSupportBlock<OverheadLineSupportBlockEntity>,OverheadLineSupportBlockEntity> OVERHEAD_LINE_SUPPORT_C =
@@ -89,6 +109,7 @@ public class AllOverheadLineSupportBlocks {
                             AllWires.OVERHEAD_LINE_WIRE,
                             AllWires.ELECTRONIC_WIRE
                     )
+                    .maxConnections(8)
                     .shouldCustomRenderItem(true)
                     .submit(AllElements.testRegistry);
 
@@ -106,6 +127,7 @@ public class AllOverheadLineSupportBlocks {
                             AllWires.OVERHEAD_LINE_WIRE,
                             AllWires.ELECTRONIC_WIRE
                     )
+                    .maxConnections(8)
                     .shouldCustomRenderItem(true)
                     .submit(AllElements.testRegistry);
 
@@ -144,6 +166,7 @@ public class AllOverheadLineSupportBlocks {
                             AllWires.OVERHEAD_LINE_WIRE,
                             AllWires.ELECTRONIC_WIRE
                     )
+                    .maxConnections(1)
                     .withConnectionPointBuilder(OverheadLineConnectionPoints::getEndCounterWeightConnectionPointIf)
                     .submit(AllElements.testRegistry);
     public static void invoke(){

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/OverheadLineEndWeightBlockEntity.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/OverheadLineEndWeightBlockEntity.java
@@ -1,10 +1,12 @@
 package willow.train.kuayue.systems.overhead_line.block.support;
 
+import com.mojang.math.Vector3f;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.phys.Vec3;
 import willow.train.kuayue.systems.overhead_line.wire.AllWires;
 
 
@@ -57,16 +59,90 @@ public class OverheadLineEndWeightBlockEntity extends OverheadLineSupportBlockEn
 
     @Override
     public void onConnectionModification() {
-        super.onConnectionModification();
         if(connections.isEmpty())
             renderState = RenderState.EMPTY;
         else if(connections.parallelStream().anyMatch((connection)-> connection.type() == AllWires.OVERHEAD_LINE_WIRE.getWireType()))
             renderState = RenderState.DUAL;
         else
             renderState = RenderState.SINGLE;
+
+        if(this.preConnectionsSize == 0 && !connections.isEmpty()) {
+            this.calculateDynamicRotation();
+        }
+        this.preConnectionsSize = connections.size();
+
+        super.onConnectionModification();
+
+        this.notifyUpdate();
     }
+
+    private int preConnectionsSize = 0;
 
     public RenderState getRenderState() {
         return renderState;
+    }
+
+    private void calculateDynamicRotation() {
+        if(connections.isEmpty()){
+            return;
+        }
+        Connection connection = connections.get(0);
+
+        Vec3 myPos = Vec3.atCenterOf(this.getBlockPos());
+        Vec3 targetPos = getDynamicTargetPosition(connection);
+
+        float absoluteAngle = calculateAngle(myPos, targetPos);
+
+        float facingAngle = - this.getBlockState().getValue(OverheadLineSupportBlock.FACING).getOpposite().toYRot() - 90;
+        this.rotation = absoluteAngle - facingAngle;
+
+        while (this.rotation > 180) this.rotation -= 360;
+        while (this.rotation <= -180) this.rotation += 360;
+    }
+
+    private Vec3 getDynamicTargetPosition(Connection connection) {
+        BlockPos targetBlockPos = connection.absolutePos();
+        BlockPos myBlockPos = this.getBlockPos();
+        if (level != null) {
+            var targetBlockEntity = level.getBlockEntity(targetBlockPos);
+
+            if (targetBlockEntity instanceof OverheadLineSupportBlockEntity targetSupport) {
+                return targetSupport.getConnectionPointByIndex(connection.targetIndex(), connection.type());
+            }
+        }
+
+        Vector3f toPos = connection.toPosition();
+        Vec3 relativePos = Vec3.atCenterOf(targetBlockPos.subtract(myBlockPos));
+        return relativePos.add(toPos.x(), toPos.y(), toPos.z());
+    }
+
+    private float calculateAngle(Vec3 pos1, Vec3 pos2) {
+        double dx = pos2.x() - pos1.x();
+        double dz = pos2.z() - pos1.z();
+
+        double horizontal_distance = Math.sqrt(dx * dx + dz * dz);
+
+        if (horizontal_distance < 1e-6) {
+            return 0.0f;
+        }
+
+        double angleRadians = Math.atan2(-dz, dx);
+        double result = Math.toDegrees(angleRadians);
+        if(result < 0) {
+            result += 360;
+        }
+
+        result = result % 360;
+
+        return (float) result;
+    }
+
+    @Override
+    protected void onConnectionPositionUpdated(Connection updatedConnection, boolean fromExternal) {
+        super.onConnectionPositionUpdated(updatedConnection, fromExternal);
+        if(fromExternal && !this.connections.isEmpty()) {
+            this.onConnectionModification();
+            this.calculateDynamicRotation();
+        }
     }
 }

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/OverheadLineSupportB2Block.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/OverheadLineSupportB2Block.java
@@ -1,0 +1,19 @@
+package willow.train.kuayue.systems.overhead_line.block.support;
+
+import net.minecraft.world.level.block.entity.BlockEntityType;
+
+public class OverheadLineSupportB2Block extends OverheadLineSupportBlock<OverheadLineSupportB2BlockEntity>{
+    public OverheadLineSupportB2Block(Properties pProperties) {
+        super(pProperties);
+    }
+
+    @Override
+    public Class<OverheadLineSupportB2BlockEntity> getBlockEntityClass() {
+        return OverheadLineSupportB2BlockEntity.class;
+    }
+
+    @Override
+    public BlockEntityType<OverheadLineSupportB2BlockEntity> getBlockEntityType() {
+        return AllOverheadLineSupportBlocks.OVERHEAD_LINE_SUPPORT_B2_BLOCK_ENTITY.getType();
+    }
+}

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/OverheadLineSupportB2BlockEntity.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/OverheadLineSupportB2BlockEntity.java
@@ -1,0 +1,31 @@
+package willow.train.kuayue.systems.overhead_line.block.support;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
+import willow.train.kuayue.systems.overhead_line.types.OverheadLineType;
+import willow.train.kuayue.systems.overhead_line.wire.AllWires;
+
+public class OverheadLineSupportB2BlockEntity extends OverheadLineSupportBlockEntity{
+
+    public OverheadLineSupportB2BlockEntity(BlockPos blockPos, BlockState blockState) {
+        super(blockPos, blockState);
+    }
+
+    public OverheadLineSupportB2BlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
+        super(type, pos, state);
+    }
+
+    @Override
+    public Vec3 getConnectionPointByIndex(int index, OverheadLineType wireType) {
+        Vec3 basePoint = getActualConnectionPoints().get(index);
+
+        float offset = 0f;
+        if(wireType.equals(AllWires.OVERHEAD_LINE_WIRE.getWireType())){
+            offset = -1.33f;
+        }
+
+        return basePoint.add(0, offset, 0);
+    }
+}

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/OverheadLineSupportBBlock.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/OverheadLineSupportBBlock.java
@@ -1,0 +1,19 @@
+package willow.train.kuayue.systems.overhead_line.block.support;
+
+import net.minecraft.world.level.block.entity.BlockEntityType;
+
+public class OverheadLineSupportBBlock extends OverheadLineSupportBlock<OverheadLineSupportBBlockEntity> {
+    public OverheadLineSupportBBlock(Properties pProperties) {
+        super(pProperties);
+    }
+
+    @Override
+    public Class<OverheadLineSupportBBlockEntity> getBlockEntityClass() {
+        return OverheadLineSupportBBlockEntity.class;
+    }
+
+    @Override
+    public BlockEntityType<OverheadLineSupportBBlockEntity> getBlockEntityType() {
+        return AllOverheadLineSupportBlocks.OVERHEAD_LINE_SUPPORT_B_BLOCK_ENTITY.getType();
+    }
+}

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/OverheadLineSupportBBlockEntity.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/OverheadLineSupportBBlockEntity.java
@@ -1,0 +1,32 @@
+package willow.train.kuayue.systems.overhead_line.block.support;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
+import willow.train.kuayue.systems.overhead_line.types.OverheadLineType;
+import willow.train.kuayue.systems.overhead_line.wire.AllWires;
+
+public class OverheadLineSupportBBlockEntity extends OverheadLineSupportBlockEntity{
+
+    public OverheadLineSupportBBlockEntity(BlockPos blockPos, BlockState blockState) {
+        super(blockPos, blockState);
+    }
+
+    public OverheadLineSupportBBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
+        super(type, pos, state);
+    }
+
+    @Override
+    public Vec3 getConnectionPointByIndex(int index, OverheadLineType wireType) {
+        Vec3 basePoint = getActualConnectionPoints().get(index);
+
+        float offset = 0f;
+        if(wireType.equals(AllWires.OVERHEAD_LINE_WIRE.getWireType())){
+            offset = -1.3f;
+        }
+
+        return basePoint.add(0, offset, 0);
+    }
+}
+

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/OverheadLineSupportBlock.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/OverheadLineSupportBlock.java
@@ -1,12 +1,18 @@
 package willow.train.kuayue.systems.overhead_line.block.support;
 
+import com.simibubi.create.AllItems;
 import com.simibubi.create.content.equipment.wrench.IWrenchable;
 import com.simibubi.create.foundation.block.IBE;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -16,6 +22,8 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.Nullable;
 import willow.train.kuayue.systems.overhead_line.OverheadLineSystem;
 
@@ -65,5 +73,29 @@ public abstract class OverheadLineSupportBlock<T extends OverheadLineSupportBloc
     @Override
     public void onPlace(BlockState pState, Level pLevel, BlockPos pPos, BlockState pOldState, boolean pIsMoving) {
         pLevel.scheduleTick(pPos, pState.getBlock(), 2);
+    }
+
+    @Override
+    public InteractionResult use(BlockState pState, Level pLevel, BlockPos pPos, Player pPlayer, InteractionHand pHand, BlockHitResult pHit) {
+        ItemStack item = pPlayer.getItemInHand(pHand);
+        
+        if (item.is(AllItems.WRENCH.get())) {
+            if (!pLevel.isClientSide) {
+                net.minecraft.world.level.block.entity.BlockEntity rawBlockEntity = pLevel.getBlockEntity(pPos);
+                
+                if (rawBlockEntity instanceof OverheadLineSupportBlockEntity) {
+                    OverheadLineSupportBlockEntity blockEntity = (OverheadLineSupportBlockEntity) rawBlockEntity;
+                    try {
+                        NetworkHooks.openScreen((ServerPlayer) pPlayer, blockEntity, pPos);
+                    } catch (Exception e) {
+                        System.out.println("[ERROR] Failed to open GUI: " + e.getMessage());
+                        e.printStackTrace();
+                    }
+                }
+            }
+            return InteractionResult.SUCCESS;
+        }
+        
+        return InteractionResult.PASS;
     }
 }

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/OverheadLineSupportBlockReg.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/OverheadLineSupportBlockReg.java
@@ -30,6 +30,7 @@ public class OverheadLineSupportBlockReg<T extends OverheadLineSupportBlock<V>, 
     private Supplier<BlockEntityRendererBuilder<OverheadLineSupportBlockEntity>> renderer = null;
     private List<ResourceLocation> lineRenderModes = List.of();
     private List<Vec3> connectionPoints = List.of();
+    private int maxConnections = Integer.MAX_VALUE;
 
     private OverheadLineBlockDynamicConfiguration.ConnectionPointBuilder connectionPointBuilder = null;
 
@@ -79,7 +80,8 @@ public class OverheadLineSupportBlockReg<T extends OverheadLineSupportBlock<V>, 
         OverheadLineBlockDynamicConfiguration configuration = new OverheadLineBlockDynamicConfiguration(
                 connectionPointBuilder != null ? connectionPointBuilder : (a,b,c)->this.connectionPoints,
                 allowedWireTypePredictor != null ? allowedWireTypePredictor : allowedTypes::contains,
-                this.lineRenderModes
+                this.lineRenderModes,
+                this.maxConnections
         );
         OverheadLineSupportBlockEntity.registerPoint(this::getBlock, configuration);
         return this;
@@ -128,6 +130,11 @@ public class OverheadLineSupportBlockReg<T extends OverheadLineSupportBlock<V>, 
 
     public OverheadLineSupportBlockReg<T, V> connectionPoints(Vec3 ...connectionPositions) {
         this.connectionPoints = List.of(connectionPositions);
+        return this;
+    }
+
+    public OverheadLineSupportBlockReg<T, V> maxConnections(int maxConnections) {
+        this.maxConnections = maxConnections;
         return this;
     }
 

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/variants/AllOverheadLineSupportModels.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/variants/AllOverheadLineSupportModels.java
@@ -3,6 +3,7 @@ package willow.train.kuayue.systems.overhead_line.block.support.variants;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Matrix4f;
 import com.mojang.math.Quaternion;
+import com.mojang.math.Vector3f;
 import kasuga.lib.core.client.model.BedrockModelLoader;
 import kasuga.lib.core.client.model.anim_model.AnimModel;
 import net.minecraft.Util;
@@ -72,6 +73,26 @@ public class AllOverheadLineSupportModels {
             pPoseStack.translate(connection.x, connection.y, connection.z);
             AllOverheadLineSupportModels.KUAYUE_TEST.render(pPoseStack, pBufferSource, LightTexture.FULL_BRIGHT, pPackedOverlay);
             pPoseStack.popPose();
+        }
+    }
+
+    public static void applyOffset(PoseStack pPoseStack, OverheadLineSupportBlockEntity entity){
+        float xOffset = entity.getXOffset();
+        float yOffset = entity.getYOffset();
+        float zOffset = entity.getZOffset();
+
+        if (Math.abs(xOffset) > 1e-6 || Math.abs(yOffset) > 1e-6 || Math.abs(zOffset) > 1e-6) {
+            pPoseStack.translate(-xOffset, yOffset, -zOffset);
+        }
+    }
+
+    public static void applyRotation(PoseStack pPoseStack, OverheadLineSupportBlockEntity entity){
+        float rotation = entity.getRotation();
+
+        if (Math.abs(rotation) > 1e-6) {
+            pPoseStack.translate(0.5, 0, 0.5);
+            pPoseStack.mulPose(Vector3f.YP.rotationDegrees(rotation));
+            pPoseStack.translate(-0.5, 0, -0.5);
         }
     }
 

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/variants/OverheadLineBlockDynamicConfiguration.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/variants/OverheadLineBlockDynamicConfiguration.java
@@ -13,7 +13,8 @@ import java.util.function.Predicate;
 public record OverheadLineBlockDynamicConfiguration(
         ConnectionPointBuilder connectionPoints,
         Predicate<OverheadLineType> typePredictor,
-        List<ResourceLocation> renderTypes
+        List<ResourceLocation> renderTypes,
+        int maxConnections
 ) {
     public static interface ConnectionPointBuilder {
         public List<Vec3> get(Level level, BlockPos blockPos, BlockState blockState);

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/variants/OverheadLineEndCounterWeightRenderer.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/variants/OverheadLineEndCounterWeightRenderer.java
@@ -22,9 +22,18 @@ public class OverheadLineEndCounterWeightRenderer implements BlockEntityRenderer
 
     @Override
     public void render(OverheadLineSupportBlockEntity pBlockEntity, float pPartialTick, PoseStack pPoseStack, MultiBufferSource pBufferSource, int pPackedLight, int pPackedOverlay) {
-        if(!(pBlockEntity instanceof OverheadLineEndWeightBlockEntity blockEntity)) {
-            return;
-        }
+        pPoseStack.pushPose();
+
+        OverheadLineEndWeightBlockEntity blockEntity = (OverheadLineEndWeightBlockEntity) pBlockEntity;
+
+        pPoseStack.mulPoseMatrix(
+                AllOverheadLineSupportModels.getDirectionOf.apply(
+                        pBlockEntity.getBlockState().getValue(OverheadLineSupportBlock.FACING), 1.3f
+                )
+        );
+
+        AllOverheadLineSupportModels.applyRotation(pPoseStack, pBlockEntity);
+        AllOverheadLineSupportModels.applyOffset(pPoseStack, pBlockEntity);
 
         switch (blockEntity.getRenderState()){
             case EMPTY -> {
@@ -40,6 +49,8 @@ public class OverheadLineEndCounterWeightRenderer implements BlockEntityRenderer
                 break;
             }
         }
+
+        pPoseStack.popPose();
     }
 
     private void renderEmpty(
@@ -51,11 +62,6 @@ public class OverheadLineEndCounterWeightRenderer implements BlockEntityRenderer
             int pPackedOverlay
     ) {
         pPoseStack.pushPose();
-        pPoseStack.mulPoseMatrix(
-                AllOverheadLineSupportModels.getDirectionOf.apply(
-                        pBlockEntity.getBlockState().getValue(OverheadLineSupportBlock.FACING), 1.3f
-                )
-        );
         AllOverheadLineSupportModels.OVERHEAD_LINE_END_COUNTERWEIGHT_EMPTY.render(
                 pPoseStack,
                 pBufferSource,
@@ -87,12 +93,16 @@ public class OverheadLineEndCounterWeightRenderer implements BlockEntityRenderer
             int pPackedOverlay
     ) {
         pPoseStack.pushPose();
-        pPoseStack.mulPoseMatrix(
-                AllOverheadLineSupportModels.getDirectionOf.apply(
-                        pBlockEntity.getBlockState().getValue(OverheadLineSupportBlock.FACING), 1.3f
-                )
-        );
         AllOverheadLineSupportModels.OVERHEAD_LINE_END_COUNTERWEIGHT_SMALL.render(
+                pPoseStack,
+                pBufferSource,
+                pPackedLight,
+                pPackedOverlay
+        );
+
+        this.renderHangerLineSmall(
+                pBlockEntity,
+                pPartialTick,
                 pPoseStack,
                 pBufferSource,
                 pPackedLight,
@@ -122,12 +132,16 @@ public class OverheadLineEndCounterWeightRenderer implements BlockEntityRenderer
             int pPackedOverlay
     ) {
         pPoseStack.pushPose();
-        pPoseStack.mulPoseMatrix(
-                AllOverheadLineSupportModels.getDirectionOf.apply(
-                        pBlockEntity.getBlockState().getValue(OverheadLineSupportBlock.FACING), 1.3f
-                )
-        );
         AllOverheadLineSupportModels.OVERHEAD_LINE_END_COUNTERWEIGHT.render(
+                pPoseStack,
+                pBufferSource,
+                pPackedLight,
+                pPackedOverlay
+        );
+
+        this.renderHangerLine(
+                pBlockEntity,
+                pPartialTick,
                 pPoseStack,
                 pBufferSource,
                 pPackedLight,
@@ -161,6 +175,7 @@ public class OverheadLineEndCounterWeightRenderer implements BlockEntityRenderer
     ) {
         int intHeight = pBlockEntity.getHeight();
         float height = (float) pBlockEntity.getHeight();
+        float yoffset = pBlockEntity.getYOffset();
 
         if(intHeight < 1) {
             return;
@@ -172,12 +187,56 @@ public class OverheadLineEndCounterWeightRenderer implements BlockEntityRenderer
         if(height < 1.0) {
             height = 1.0f;
         }
-        pPoseStack.translate(0, - (height - 1) ,0);
+        pPoseStack.translate(0, - (height/1.3f + yoffset - 1) ,0);
         model.render(
                 pPoseStack,
                 pBufferSource,
                 pPackedLight,
                 pPackedOverlay
         );
+    }
+
+    private void renderHangerLineSmall(
+            OverheadLineEndWeightBlockEntity pBlockEntity,
+            float pPartialTick,
+            PoseStack pPoseStack,
+            MultiBufferSource pBufferSource,
+            int pPackedLight,
+            int pPackedOverlay
+    ) {
+        pPoseStack.pushPose();
+        pPoseStack.translate(-0.82f, -0.15f, 0.0);
+        for(int i = 0; i < pBlockEntity.getHeight() + pBlockEntity.getYOffset() - 3; i++) {
+            pPoseStack.translate(0.0, -0.77f, 0.0);
+            AllOverheadLineSupportModels.OVERHEAD_LINE_END_COUNTERWEIGHT_HANGER_LINE_SMALL.render(
+                    pPoseStack,
+                    pBufferSource,
+                    pPackedLight,
+                    pPackedOverlay
+            );
+        }
+        pPoseStack.popPose();
+    }
+
+    private void renderHangerLine(
+            OverheadLineEndWeightBlockEntity pBlockEntity,
+            float pPartialTick,
+            PoseStack pPoseStack,
+            MultiBufferSource pBufferSource,
+            int pPackedLight,
+            int pPackedOverlay
+    ) {
+        pPoseStack.pushPose();
+        pPoseStack.translate(-0.2f, -0.15f, 0.0);
+        for(int i = 0; i < pBlockEntity.getHeight() + pBlockEntity.getYOffset() - 3; i++) {
+            pPoseStack.translate(0.0, -0.77f, 0.0);
+            AllOverheadLineSupportModels.OVERHEAD_LINE_END_COUNTERWEIGHT_HANGER_LINE.render(
+                    pPoseStack,
+                    pBufferSource,
+                    pPackedLight,
+                    pPackedOverlay
+            );
+        }
+        pPoseStack.popPose();
     }
 }

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/variants/OverheadLineInsulatorRenderer.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/variants/OverheadLineInsulatorRenderer.java
@@ -28,9 +28,13 @@ public abstract class OverheadLineInsulatorRenderer {
             pPoseStack.pushPose();
             pPoseStack.mulPoseMatrix(
                     AllOverheadLineSupportModels.getDirectionOf.apply(
-                            pBlockEntity.getBlockState().getValue(OverheadLineSupportBlock.FACING), 1.0f
+                            pBlockEntity.getBlockState().getValue(OverheadLineSupportBlock.FACING), 1.3f
                     )
             );
+
+            AllOverheadLineSupportModels.applyRotation(pPoseStack, pBlockEntity);
+            AllOverheadLineSupportModels.applyOffset(pPoseStack, pBlockEntity);
+
             (pBlockEntity.getBlockState().getValue(OverheadLineSupportInsulatorBlock.WALL)
                     ? AllOverheadLineSupportModels.OVERHEAD_LINE_SUPPORT_INSULATOR_A_WALL
                     :AllOverheadLineSupportModels.OVERHEAD_LINE_SUPPORT_INSULATOR_A)
@@ -51,9 +55,13 @@ public abstract class OverheadLineInsulatorRenderer {
             pPoseStack.pushPose();
             pPoseStack.mulPoseMatrix(
                     AllOverheadLineSupportModels.getDirectionOf.apply(
-                            pBlockEntity.getBlockState().getValue(OverheadLineSupportBlock.FACING), 1.0f
+                            pBlockEntity.getBlockState().getValue(OverheadLineSupportBlock.FACING), 1.3f
                     )
             );
+
+            AllOverheadLineSupportModels.applyRotation(pPoseStack, pBlockEntity);
+            AllOverheadLineSupportModels.applyOffset(pPoseStack, pBlockEntity);
+
             (pBlockEntity.getBlockState().getValue(OverheadLineSupportInsulatorBlock.WALL)
                     ? AllOverheadLineSupportModels.OVERHEAD_LINE_SUPPORT_INSULATOR_B_WALL
                     :AllOverheadLineSupportModels.OVERHEAD_LINE_SUPPORT_INSULATOR_B)

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/variants/OverheadLineSupportARenderer.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/variants/OverheadLineSupportARenderer.java
@@ -30,7 +30,10 @@ public abstract class OverheadLineSupportARenderer {
                             pBlockEntity.getBlockState().getValue(OverheadLineSupportBlock.FACING), 1.3f
                     )
             );
-            // pPoseStack.mulPose(new Quaternion(90, 0, 0, true));
+
+            AllOverheadLineSupportModels.applyRotation(pPoseStack, pBlockEntity);
+            AllOverheadLineSupportModels.applyOffset(pPoseStack, pBlockEntity);
+
             AllOverheadLineSupportModels.OVERHEAD_LINE_SUPPORT_A1_MODEL.render(
                     pPoseStack,
                     pBufferSource,
@@ -51,6 +54,10 @@ public abstract class OverheadLineSupportARenderer {
                             pBlockEntity.getBlockState().getValue(OverheadLineSupportBlock.FACING), 1.3f
                     )
             );
+
+            AllOverheadLineSupportModels.applyRotation(pPoseStack, pBlockEntity);
+            AllOverheadLineSupportModels.applyOffset(pPoseStack, pBlockEntity);
+
             AllOverheadLineSupportModels.OVERHEAD_LINE_SUPPORT_A2_MODEL.render(
                     pPoseStack,
                     pBufferSource,

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/variants/OverheadLineSupportBRenderer.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/variants/OverheadLineSupportBRenderer.java
@@ -19,6 +19,10 @@ public abstract class OverheadLineSupportBRenderer {
                             pBlockEntity.getBlockState().getValue(OverheadLineSupportBlock.FACING), 1.3f
                     )
             );
+
+            AllOverheadLineSupportModels.applyRotation(pPoseStack, pBlockEntity);
+            AllOverheadLineSupportModels.applyOffset(pPoseStack, pBlockEntity);
+
             AllOverheadLineSupportModels.OVERHEAD_LINE_SUPPORT_C1_MODEL.render(
                     pPoseStack,
                     pBufferSource,
@@ -39,6 +43,10 @@ public abstract class OverheadLineSupportBRenderer {
                             pBlockEntity.getBlockState().getValue(OverheadLineSupportBlock.FACING), 1.3f
                     )
             );
+
+            AllOverheadLineSupportModels.applyRotation(pPoseStack, pBlockEntity);
+            AllOverheadLineSupportModels.applyOffset(pPoseStack, pBlockEntity);
+
             pPoseStack.translate(0, -0.25, 0);
             AllOverheadLineSupportModels.OVERHEAD_LINE_SUPPORT_C2_MODEL.render(
                     pPoseStack,

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/variants/OverheadLineSupportCRenderer.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/block/support/variants/OverheadLineSupportCRenderer.java
@@ -28,6 +28,10 @@ public abstract class OverheadLineSupportCRenderer {
                             pBlockEntity.getBlockState().getValue(OverheadLineSupportBlock.FACING), 1.3f
                     )
             );
+
+            AllOverheadLineSupportModels.applyRotation(pPoseStack, pBlockEntity);
+            AllOverheadLineSupportModels.applyOffset(pPoseStack, pBlockEntity);
+
             pPoseStack.translate(0,0,-0.4);
             AllOverheadLineSupportModels.OVERHEAD_LINE_SUPPORT_A2_MODEL.render(
                     pPoseStack,
@@ -56,6 +60,10 @@ public abstract class OverheadLineSupportCRenderer {
                             pBlockEntity.getBlockState().getValue(OverheadLineSupportBlock.FACING), 1.3f
                     )
             );
+
+            AllOverheadLineSupportModels.applyRotation(pPoseStack, pBlockEntity);
+            AllOverheadLineSupportModels.applyOffset(pPoseStack, pBlockEntity);
+
             pPoseStack.translate(0,0,-0.4);
             AllOverheadLineSupportModels.OVERHEAD_LINE_SUPPORT_A1_MODEL.render(
                     pPoseStack,

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/client/AllOverheadLineMenuScreens.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/client/AllOverheadLineMenuScreens.java
@@ -1,0 +1,14 @@
+package willow.train.kuayue.systems.overhead_line.client;
+
+import kasuga.lib.registrations.common.MenuReg;
+import willow.train.kuayue.initial.AllElements;
+
+public class AllOverheadLineMenuScreens {
+
+    public static final MenuReg<OverheadLineSupportAdjustMenu, OverheadLineSupportAdjustScreen> OVERHEAD_LINE_SUPPORT_ADJUST =
+            new MenuReg<OverheadLineSupportAdjustMenu, OverheadLineSupportAdjustScreen>("overhead_line_support_adjust")
+                    .withMenuAndScreen(OverheadLineSupportAdjustMenu::new, () -> OverheadLineSupportAdjustScreen::new)
+                    .submit(AllElements.testRegistry);
+
+    public static void invoke(){}
+}

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/client/OverheadLineSupportAdjustMenu.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/client/OverheadLineSupportAdjustMenu.java
@@ -1,0 +1,69 @@
+package willow.train.kuayue.systems.overhead_line.client;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.*;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.jetbrains.annotations.Nullable;
+import willow.train.kuayue.systems.overhead_line.block.support.OverheadLineSupportBlockEntity;
+
+public class OverheadLineSupportAdjustMenu extends AbstractContainerMenu {
+
+    private OverheadLineSupportBlockEntity blockEntity;
+
+    public OverheadLineSupportAdjustMenu(@Nullable MenuType<?> pMenuType, int pContainerId) {
+        super(pMenuType, pContainerId);
+
+        this.addDataSlot(
+                new DataSlot() {
+                    @Override
+                    public int get() {
+                        return 0;
+                    }
+
+                    @Override
+                    public void set(int pValue) {}
+                });
+    }
+
+    public OverheadLineSupportAdjustMenu(int containerId, Inventory inv, FriendlyByteBuf extraData) {
+        this(AllOverheadLineMenuScreens.OVERHEAD_LINE_SUPPORT_ADJUST.getMenuType(), containerId);
+        BlockEntity entity = inv.player.level.getBlockEntity(extraData.readBlockPos());
+        if (entity instanceof OverheadLineSupportBlockEntity) {
+            this.blockEntity = (OverheadLineSupportBlockEntity) entity;
+        }
+    }
+
+    public OverheadLineSupportAdjustMenu(int containerId, Inventory inv, BlockEntity entity, ContainerData data) {
+        super(AllOverheadLineMenuScreens.OVERHEAD_LINE_SUPPORT_ADJUST.getMenuType(), containerId);
+        this.blockEntity = (OverheadLineSupportBlockEntity) entity;
+    }
+
+    public OverheadLineSupportAdjustMenu(int containerId, Inventory inv, OverheadLineSupportBlockEntity blockEntity) {
+        super(AllOverheadLineMenuScreens.OVERHEAD_LINE_SUPPORT_ADJUST.getMenuType(), containerId);
+        this.blockEntity = blockEntity;
+    }
+
+    public OverheadLineSupportBlockEntity getBlockEntity() {
+        return blockEntity;
+    }
+
+    @Override
+    public ItemStack quickMoveStack(Player pPlayer, int pIndex) {
+        return ItemStack.EMPTY;
+    }
+
+    @Override
+    public boolean stillValid(Player pPlayer) {
+        if (blockEntity == null || blockEntity.getLevel() == null) {
+            return false;
+        }
+        return pPlayer.distanceToSqr(
+                blockEntity.getBlockPos().getX() + 0.5,
+                blockEntity.getBlockPos().getY() + 0.5,
+                blockEntity.getBlockPos().getZ() + 0.5
+        ) <= 64.0;
+    }
+}

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/client/OverheadLineSupportAdjustScreen.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/client/OverheadLineSupportAdjustScreen.java
@@ -1,0 +1,456 @@
+package willow.train.kuayue.systems.overhead_line.client;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.AbstractSliderButton;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import willow.train.kuayue.initial.AllPackets;
+import willow.train.kuayue.systems.overhead_line.block.support.OverheadLineSupportBlockEntity;
+import willow.train.kuayue.systems.overhead_line.packet.C2SOverheadLineSupportAdjustPacket;
+
+public class OverheadLineSupportAdjustScreen extends AbstractContainerScreen<OverheadLineSupportAdjustMenu> {
+
+    private OverheadLineSupportBlockEntity blockEntity;
+    private OverheadLineSupportSlider xOffsetSlider, yOffsetSlider, zOffsetSlider, rotationSlider;
+    private EditBox xOffsetEditBox, yOffsetEditBox, zOffsetEditBox, rotationEditBox;
+    private Button confirmButton, cancelButton;
+    
+    private float tempXOffset, tempYOffset, tempZOffset, tempRotation;
+    private float originalXOffset, originalYOffset, originalZOffset, originalRotation;
+    
+    private static final int SLIDER_WIDTH = 200;
+    private static final int SLIDER_HEIGHT = 20;
+    private static final int SLIDER_SPACING = 25;
+    private static final int EDITBOX_WIDTH = 60;
+    private static final int EDITBOX_HEIGHT = 20;
+    private static final int EDITBOX_MARGIN = 10;
+    private static final int GUI_LEFT = 20;
+    private static final int GUI_TOP = 20;
+
+    public OverheadLineSupportAdjustScreen(OverheadLineSupportAdjustMenu pMenu, Inventory pPlayerInventory, Component pTitle) {
+        super(pMenu, pPlayerInventory, pTitle);
+        this.blockEntity = pMenu.getBlockEntity();
+        this.imageWidth = 256;
+        this.imageHeight = 200;
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        
+        if (blockEntity == null) {
+            return;
+        }
+
+        originalXOffset = blockEntity.getXOffset();
+        originalYOffset = blockEntity.getYOffset();
+        originalZOffset = blockEntity.getZOffset();
+        originalRotation = blockEntity.getManualRotation();
+
+        tempXOffset = originalXOffset;
+        tempYOffset = originalYOffset;
+        tempZOffset = originalZOffset;
+        tempRotation = originalRotation;
+
+        this.leftPos = GUI_LEFT;
+        this.topPos = GUI_TOP;
+        
+        int startX = leftPos;
+        int startY = topPos;
+
+        boolean isEndWeight = isEndWeightBlock();
+
+        xOffsetSlider = addRenderableWidget(new OverheadLineSupportSlider(
+            startX, startY, SLIDER_WIDTH, SLIDER_HEIGHT,
+            (tempXOffset + 1.0f) / 2.0f,
+            Component.literal("X Offset"),
+            OffsetType.X
+        ));
+        
+        xOffsetEditBox = addRenderableWidget(new EditBox(font, 
+            startX + SLIDER_WIDTH + EDITBOX_MARGIN, startY, EDITBOX_WIDTH, EDITBOX_HEIGHT, 
+            Component.literal("X Offset")));
+        xOffsetEditBox.setValue(String.format("%.2f", tempXOffset));
+        xOffsetEditBox.setResponder(value -> onEditBoxChanged(OffsetType.X, value));
+        xOffsetEditBox.setMaxLength(10);
+        xOffsetEditBox.setBordered(true);
+        
+        yOffsetSlider = addRenderableWidget(new OverheadLineSupportSlider(
+            startX, startY + SLIDER_SPACING, SLIDER_WIDTH, SLIDER_HEIGHT,
+            (tempYOffset + 1.0f) / 2.0f,
+            Component.literal("Y Offset"),
+            OffsetType.Y
+        ));
+        
+        yOffsetEditBox = addRenderableWidget(new EditBox(font, 
+            startX + SLIDER_WIDTH + EDITBOX_MARGIN, startY + SLIDER_SPACING, EDITBOX_WIDTH, EDITBOX_HEIGHT, 
+            Component.literal("Y Offset")));
+        yOffsetEditBox.setValue(String.format("%.2f", tempYOffset));
+        yOffsetEditBox.setResponder(value -> onEditBoxChanged(OffsetType.Y, value));
+        yOffsetEditBox.setMaxLength(10);
+        yOffsetEditBox.setBordered(true);
+        
+        zOffsetSlider = addRenderableWidget(new OverheadLineSupportSlider(
+            startX, startY + SLIDER_SPACING * 2, SLIDER_WIDTH, SLIDER_HEIGHT,
+            (tempZOffset + 1.0f) / 2.0f,
+            Component.literal("Z Offset"),
+            OffsetType.Z
+        ));
+        
+        zOffsetEditBox = addRenderableWidget(new EditBox(font, 
+            startX + SLIDER_WIDTH + EDITBOX_MARGIN, startY + SLIDER_SPACING * 2, EDITBOX_WIDTH, EDITBOX_HEIGHT, 
+            Component.literal("Z Offset")));
+        zOffsetEditBox.setValue(String.format("%.2f", tempZOffset));
+        zOffsetEditBox.setResponder(value -> onEditBoxChanged(OffsetType.Z, value));
+        zOffsetEditBox.setMaxLength(10);
+        zOffsetEditBox.setBordered(true);
+
+        int buttonYOffset = SLIDER_SPACING * 3;
+        if (!isEndWeight) {
+            rotationSlider = addRenderableWidget(new OverheadLineSupportSlider(
+                startX, startY + SLIDER_SPACING * 3, SLIDER_WIDTH, SLIDER_HEIGHT,
+                (tempRotation + 45.0f) / 90.0f,
+                Component.literal("Rotation"),
+                OffsetType.ROTATION
+            ));
+            
+            rotationEditBox = addRenderableWidget(new EditBox(font, 
+                startX + SLIDER_WIDTH + EDITBOX_MARGIN, startY + SLIDER_SPACING * 3, EDITBOX_WIDTH, EDITBOX_HEIGHT, 
+                Component.literal("Rotation")));
+            rotationEditBox.setValue(String.format("%.2f", tempRotation));
+            rotationEditBox.setResponder(value -> onEditBoxChanged(OffsetType.ROTATION, value));
+            rotationEditBox.setMaxLength(10);
+            rotationEditBox.setBordered(true);
+            
+            buttonYOffset = SLIDER_SPACING * 4;
+        }
+
+        int buttonY = startY + buttonYOffset + 10;
+        confirmButton = addRenderableWidget(new Button(
+            startX, buttonY, 70, 20,
+            Component.literal("Confirm"), 
+            this::onConfirm
+        ));
+        
+        addRenderableWidget(new Button(
+            startX + 75, buttonY, 70, 20,
+            Component.literal("Reset"), 
+            this::onReset
+        ));
+        
+        cancelButton = addRenderableWidget(new Button(
+            startX + 150, buttonY, 70, 20,
+            Component.literal("Cancel"), 
+            this::onCancel
+        ));
+    }
+
+    private boolean isEndWeightBlock() {
+        if (blockEntity == null) return false;
+        String blockName = blockEntity.getBlockState().getBlock().getClass().getSimpleName();
+        return blockName.contains("EndWeight");
+    }
+    
+    private void onEditBoxChanged(OffsetType type, String value) {
+        if (value.isEmpty()) return;
+        
+        try {
+            float parsedValue = Float.parseFloat(value);
+
+            float minValue, maxValue;
+            switch (type) {
+                case X, Y, Z -> {
+                    minValue = -1.0f;
+                    maxValue = 1.0f;
+                }
+                case ROTATION -> {
+                    minValue = -45.0f;
+                    maxValue = 45.0f;
+                }
+                default -> {
+                    return;
+                }
+            }
+
+            float clampedValue = Math.max(minValue, Math.min(maxValue, parsedValue));
+
+            switch (type) {
+                case X -> {
+                    tempXOffset = clampedValue;
+                    if (xOffsetSlider != null) {
+                        xOffsetSlider.setSliderValue((clampedValue + 1.0f) / 2.0f);
+                    }
+                }
+                case Y -> {
+                    tempYOffset = clampedValue;
+                    if (yOffsetSlider != null) {
+                        yOffsetSlider.setSliderValue((clampedValue + 1.0f) / 2.0f);
+                    }
+                }
+                case Z -> {
+                    tempZOffset = clampedValue;
+                    if (zOffsetSlider != null) {
+                        zOffsetSlider.setSliderValue((clampedValue + 1.0f) / 2.0f);
+                    }
+                }
+                case ROTATION -> {
+                    tempRotation = clampedValue;
+                    if (rotationSlider != null) {
+                        rotationSlider.setSliderValue((clampedValue + 45.0f) / 90.0f);
+                    }
+                }
+            }
+
+            if (blockEntity != null) {
+                blockEntity.setTransformParameters(tempXOffset, tempYOffset, tempZOffset, tempRotation);
+            }
+        } catch (NumberFormatException ignored) {
+        }
+    }
+
+    private void onConfirm(Button button) {
+        if (blockEntity != null) {
+            AllPackets.CHANNEL.sendToServer(new C2SOverheadLineSupportAdjustPacket(
+                blockEntity.getBlockPos(), tempXOffset, tempYOffset, tempZOffset, tempRotation));
+        }
+        this.onClose();
+    }
+
+    private void onReset(Button button) {
+        tempXOffset = 0.0f;
+        tempYOffset = 0.0f;
+        tempZOffset = 0.0f;
+        tempRotation = 0.0f;
+
+        if (xOffsetSlider != null) xOffsetSlider.setValueAndApply(0.5);
+        if (yOffsetSlider != null) yOffsetSlider.setValueAndApply(0.5);
+        if (zOffsetSlider != null) zOffsetSlider.setValueAndApply(0.5);
+        if (rotationSlider != null) rotationSlider.setValueAndApply(0.5);
+
+        // 重置输入框的值
+        if (xOffsetEditBox != null) xOffsetEditBox.setValue("0.00");
+        if (yOffsetEditBox != null) yOffsetEditBox.setValue("0.00");
+        if (zOffsetEditBox != null) zOffsetEditBox.setValue("0.00");
+        if (rotationEditBox != null) rotationEditBox.setValue("0.00");
+
+        if (blockEntity != null) {
+            blockEntity.setTransformParameters(tempXOffset, tempYOffset, tempZOffset, tempRotation);
+        }
+    }
+
+    private void onCancel(Button button) {
+        if (blockEntity != null) {
+            blockEntity.setTransformParameters(originalXOffset, originalYOffset, originalZOffset, originalRotation);
+        }
+        this.onClose();
+    }
+
+    @Override
+    protected void renderBg(PoseStack pPoseStack, float pPartialTick, int pMouseX, int pMouseY) {
+    }
+
+    @Override
+    public boolean isPauseScreen() {
+        return super.isPauseScreen();
+    }
+
+    @Override
+    public void render(PoseStack pPoseStack, int pMouseX, int pMouseY, float pPartialTick) {
+        super.render(pPoseStack, pMouseX, pMouseY, pPartialTick);
+
+        drawString(pPoseStack, font, "Overhead Line Support Adjustment", 
+                  leftPos, topPos - 15, 0xFFFFFF);
+
+        int labelX = leftPos + SLIDER_WIDTH + EDITBOX_MARGIN + EDITBOX_WIDTH + 5;
+        drawString(pPoseStack, font, "Value", labelX, topPos + 5, 0xAAAAA);
+    }
+
+    @Override
+    public boolean keyPressed(int pKeyCode, int pScanCode, int pModifiers) {
+        if (pKeyCode == 256) {
+            onCancel(null);
+            return true;
+        }
+        return super.keyPressed(pKeyCode, pScanCode, pModifiers);
+    }
+
+    @Override
+    public boolean charTyped(char pCodePoint, int pModifiers) {
+        return super.charTyped(pCodePoint, pModifiers);
+    }
+
+    @Override
+    public boolean mouseClicked(double pMouseX, double pMouseY, int pButton) {
+        return super.mouseClicked(pMouseX, pMouseY, pButton);
+    }
+
+    @Override
+    public boolean mouseDragged(double pMouseX, double pMouseY, int pButton, double pDragX, double pDragY) {
+        if (xOffsetSlider != null && xOffsetSlider.isBeingDragged()) {
+            return xOffsetSlider.mouseDragged(pMouseX, pMouseY, pButton, pDragX, pDragY);
+        }
+        
+        if (yOffsetSlider != null && yOffsetSlider.isBeingDragged()) {
+            return yOffsetSlider.mouseDragged(pMouseX, pMouseY, pButton, pDragX, pDragY);
+        }
+        
+        if (zOffsetSlider != null && zOffsetSlider.isBeingDragged()) {
+            return zOffsetSlider.mouseDragged(pMouseX, pMouseY, pButton, pDragX, pDragY);
+        }
+        
+        if (rotationSlider != null && rotationSlider.isBeingDragged()) {
+            return rotationSlider.mouseDragged(pMouseX, pMouseY, pButton, pDragX, pDragY);
+        }
+        
+        return super.mouseDragged(pMouseX, pMouseY, pButton, pDragX, pDragY);
+    }
+
+    @Override
+    public boolean mouseReleased(double pMouseX, double pMouseY, int pButton) {
+        if (xOffsetSlider != null && xOffsetSlider.isBeingDragged()) {
+            return xOffsetSlider.mouseReleased(pMouseX, pMouseY, pButton);
+        }
+        
+        if (yOffsetSlider != null && yOffsetSlider.isBeingDragged()) {
+            return yOffsetSlider.mouseReleased(pMouseX, pMouseY, pButton);
+        }
+        
+        if (zOffsetSlider != null && zOffsetSlider.isBeingDragged()) {
+            return zOffsetSlider.mouseReleased(pMouseX, pMouseY, pButton);
+        }
+        
+        if (rotationSlider != null && rotationSlider.isBeingDragged()) {
+            return rotationSlider.mouseReleased(pMouseX, pMouseY, pButton);
+        }
+        
+        return super.mouseReleased(pMouseX, pMouseY, pButton);
+    }
+
+    private void updateTempValue(OffsetType type, float value) {
+        switch (type) {
+            case X:
+                tempXOffset = value;
+                if (xOffsetEditBox != null && !xOffsetEditBox.isFocused()) {
+                    xOffsetEditBox.setValue(String.format("%.2f", value));
+                }
+                break;
+            case Y:
+                tempYOffset = value;
+                if (yOffsetEditBox != null && !yOffsetEditBox.isFocused()) {
+                    yOffsetEditBox.setValue(String.format("%.2f", value));
+                }
+                break;
+            case Z:
+                tempZOffset = value;
+                if (zOffsetEditBox != null && !zOffsetEditBox.isFocused()) {
+                    zOffsetEditBox.setValue(String.format("%.2f", value));
+                }
+                break;
+            case ROTATION:
+                tempRotation = value;
+                if (rotationEditBox != null && !rotationEditBox.isFocused()) {
+                    rotationEditBox.setValue(String.format("%.2f", value));
+                }
+                break;
+        }
+
+        if (blockEntity != null) {
+            blockEntity.setTransformParameters(tempXOffset, tempYOffset, tempZOffset, tempRotation);
+        }
+    }
+
+    private enum OffsetType {
+        X, Y, Z, ROTATION
+    }
+
+    public class OverheadLineSupportSlider extends AbstractSliderButton {
+        private final Component label;
+        private final OffsetType offsetType;
+        private boolean onClicked = false;
+
+        public OverheadLineSupportSlider(int x, int y, int width, int height, double value, Component label, OffsetType offsetType) {
+            super(x, y, width, height, Component.empty(), value);
+            this.label = label;
+            this.offsetType = offsetType;
+            this.updateMessage();
+        }
+
+        @Override
+        protected void updateMessage() {
+            if (offsetType == OffsetType.ROTATION) {
+                float rotationValue = (float) ((value - 0.5) * 90.0);
+                this.setMessage(Component.literal("Rotation = " + String.format("%.1f°", rotationValue)));
+            } else {
+                float offsetValue = (float) ((value - 0.5) * 2.0);
+                this.setMessage(label.copy().append(Component.literal(" = " + String.format("%.2f", offsetValue))));
+            }
+        }
+
+        @Override
+        protected void applyValue() {
+            float actualValue;
+            if (offsetType == OffsetType.ROTATION) {
+                actualValue = (float) ((value - 0.5) * 90.0);
+            } else {
+                actualValue = (float) ((value - 0.5) * 2.0);
+            }
+            
+            updateTempValue(offsetType, actualValue);
+        }
+
+        @Override
+        public boolean mouseClicked(double pMouseX, double pMouseY, int pButton) {
+            return super.mouseClicked(pMouseX, pMouseY, pButton);
+        }
+
+        @Override
+        public boolean mouseReleased(double pMouseX, double pMouseY, int pButton) {
+            return super.mouseReleased(pMouseX, pMouseY, pButton);
+        }
+
+        @Override
+        public void onClick(double pMouseX, double pMouseY) {
+            super.onClick(pMouseX, pMouseY);
+            this.onClicked = true;
+        }
+
+        @Override
+        public void onRelease(double pMouseX, double pMouseY) {
+            super.onRelease(pMouseX, pMouseY);
+            this.onClicked = false;
+        }
+
+        @Override
+        public boolean mouseDragged(double pMouseX, double pMouseY, int pButton, double pDragX, double pDragY) {
+            if (!onClicked) return false;
+
+            double percentage = (pMouseX - this.x) / (double) this.width;
+            percentage = Math.max(0.0, Math.min(1.0, percentage));
+            
+            this.value = percentage;
+            updateMessage();
+            applyValue();
+            
+            return true;
+        }
+
+        public void setSliderValue(double newValue) {
+            this.value = Math.max(0.0, Math.min(1.0, newValue));
+            updateMessage();
+        }
+
+        public void setValueAndApply(double newValue) {
+            this.value = Math.max(0.0, Math.min(1.0, newValue));
+            updateMessage();
+            applyValue();
+        }
+        
+        public boolean isBeingDragged() {
+            return onClicked;
+        }
+    }
+}

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/item/OverheadLineItem.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/item/OverheadLineItem.java
@@ -87,6 +87,12 @@ public class OverheadLineItem extends Item {
             return;
         }
 
+        Optional<String> canAcceptConnection = overheadLineSupportBlockEntity.checkCanAcceptNewConnection();
+        if(canAcceptConnection.isPresent()) {
+            ComponentTranslationTool.showError(player, canAcceptConnection.get(), true);
+            return;
+        }
+
         CompoundTag tag = item.getOrCreateTag();
 
         tag.put("target", NbtUtils.writeBlockPos(clickedPos));

--- a/src/main/java/willow/train/kuayue/systems/overhead_line/packet/C2SOverheadLineSupportAdjustPacket.java
+++ b/src/main/java/willow/train/kuayue/systems/overhead_line/packet/C2SOverheadLineSupportAdjustPacket.java
@@ -1,0 +1,65 @@
+package willow.train.kuayue.systems.overhead_line.packet;
+
+import kasuga.lib.core.network.C2SPacket;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraftforge.network.NetworkEvent;
+import willow.train.kuayue.systems.overhead_line.block.support.OverheadLineSupportBlockEntity;
+
+public class C2SOverheadLineSupportAdjustPacket extends C2SPacket {
+    public final BlockPos pos;
+    public final float xOffset;
+    public final float yOffset;
+    public final float zOffset;
+    public final float rotation;
+
+    public C2SOverheadLineSupportAdjustPacket(FriendlyByteBuf buf) {
+        super(buf);
+        this.pos = buf.readBlockPos();
+        this.xOffset = buf.readFloat();
+        this.yOffset = buf.readFloat();
+        this.zOffset = buf.readFloat();
+        this.rotation = buf.readFloat();
+    }
+
+    public C2SOverheadLineSupportAdjustPacket(BlockPos pos, float xOffset, float yOffset, float zOffset, float rotation) {
+        super();
+        this.pos = pos;
+        this.xOffset = xOffset;
+        this.yOffset = yOffset;
+        this.zOffset = zOffset;
+        this.rotation = rotation;
+    }
+
+    @Override
+    public void handle(NetworkEvent.Context context) {
+        context.enqueueWork(() -> {
+            ServerPlayer player = context.getSender();
+            if (player == null) return;
+
+            ServerLevel level = player.getLevel();
+            if (level == null) return;
+
+            if (player.distanceToSqr(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5) > 64.0) {
+                return;
+            }
+
+            BlockEntity blockEntity = level.getBlockEntity(pos);
+            if (blockEntity instanceof OverheadLineSupportBlockEntity supportBlockEntity) {
+                supportBlockEntity.setTransformParameters(xOffset, yOffset, zOffset, rotation);
+            }
+        });
+    }
+
+    @Override
+    public void encode(FriendlyByteBuf buf) {
+        buf.writeBlockPos(pos);
+        buf.writeFloat(xOffset);
+        buf.writeFloat(yOffset);
+        buf.writeFloat(zOffset);
+        buf.writeFloat(rotation);
+    }
+}


### PR DESCRIPTION
- Implemented offset and rotation transform for overhead line support blocks and renderers
- fix B/B2 supports' wrong connection point position
- Introduced GUI and packet for adjusting support transform parameters
- Updated rendering logic to apply offset/rotation in all relevant support and insulator renderers
- Enhanced EndWeight autorotation
- Added maxConnections config
- Improved cache management in OverheadSupportBlockRenderer