### PR TITLE
转向架修正

### DIFF
--- a/resources/generated/locomotives/stream/qj/blockstates/track_and_bogey/qj_guide_bogey_a.json
+++ b/resources/generated/locomotives/stream/qj/blockstates/track_and_bogey/qj_guide_bogey_a.json
@@ -1,0 +1,21 @@
+{
+  "variants": {
+    "axis=z,waterlogged=false": {
+      "model": "kuayue:block/bogey/qj/qj_guide_top",
+      "y": 0
+    },
+    "axis=x,waterlogged=false": {
+      "model": "kuayue:block/bogey/qj/qj_guide_top",
+      "y": 90
+    },
+    "axis=z,waterlogged=true": {
+      "model": "kuayue:block/bogey/qj/qj_guide_top",
+      "y": 0
+
+    },
+    "axis=x,waterlogged=true": {
+      "model": "ckuayue:block/bogey/qj/qj_guide_top",
+      "y": 90
+    }
+  }
+}

--- a/src/main/java/willow/train/kuayue/block/bogey/loco/renderer/SS8Renderer.java
+++ b/src/main/java/willow/train/kuayue/block/bogey/loco/renderer/SS8Renderer.java
@@ -21,7 +21,7 @@ public class SS8Renderer extends BogeyRenderer {
         return AllElements.testRegistry.asResource("block/" + path);
     }
     public static final PartialModel
-            SS8_FRAME = new PartialModel(asBlockModelResource("bogey/ss8//ss8_frame")),
+            SS8_FRAME = new PartialModel(asBlockModelResource("bogey/ss8/ss8_frame")),
             SS8_WHEEL = new PartialModel(asBlockModelResource("bogey/ss8/ss8_wheel"));
     @Override
     public void initialiseContraptionModelData(

--- a/src/main/java/willow/train/kuayue/initial/create/AllLocoBogeys.java
+++ b/src/main/java/willow/train/kuayue/initial/create/AllLocoBogeys.java
@@ -104,7 +104,7 @@ public class AllLocoBogeys {
             .size(0.915F / 2F)
             .submit(testRegistry);
 
-    public static final BogeySizeReg qjGuideAndesite = new BogeySizeReg("qj_guide_a")
+    public static final BogeySizeReg qjGuideAndesite = new BogeySizeReg("qj_guide_bogey_a")
             .size(0.915F / 2F)
             .submit(testRegistry);
 
@@ -191,7 +191,7 @@ public class AllLocoBogeys {
             .bogey(df11gAndesite.getSize(), DF11GRenderer.Andesite::new, testRegistry.asResource("df11g_bogey_a"))
             .bogey(df11gBackwardAndesite.getSize(), DF11GRenderer.Andesite.Backward::new, testRegistry.asResource("df11g_backward_bogey_a"))
             .bogey(qjMainAndesite.getSize(), QJMainRenderer.Andesite::new, testRegistry.asResource("qj_bogey_a"))
-            .bogey(qjGuideAndesite.getSize(), QJGuideRenderer.Andesite::new, testRegistry.asResource("qj_guide_a"))
+            .bogey(qjGuideAndesite.getSize(), QJGuideRenderer.Andesite::new, testRegistry.asResource("qj_guide_bogey_a"))
             .bogey(hxd3dAndesite.getSize(), HXD3DRenderer.Andesite::new, testRegistry.asResource("hxd3d_bogey_a"))
             .bogey(hxd3dBackwardAndesite.getSize(), HXD3DRenderer.Andesite.Backward::new, testRegistry.asResource("hxd3d_backward_bogey_a"))
             .bogey(dfh21Andesite.getSize(), DFH21Renderer.Andesite::new, testRegistry.asResource("dfh21_bogey_a"))


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 修正SS8转向架模型资源路径错误

- 统一QJ导向转向架注册名和资源路径

- 新增QJ导向转向架方块状态JSON文件


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SS8Renderer["修正SS8模型资源路径"] -- "路径修正" --> AllLocoBogeys["QJ导向转向架注册名和资源路径统一"]
  AllLocoBogeys -- "注册名和资源路径同步" --> qj_guide_bogey_a_json["新增QJ导向转向架方块状态JSON"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SS8Renderer.java</strong><dd><code>修正SS8转向架模型资源路径错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/willow/train/kuayue/block/bogey/loco/renderer/SS8Renderer.java

- 修正SS8_FRAME模型资源路径多余斜杠


</details>


  </td>
  <td><a href="https://github.com/KuaYueTeam/NeoKuayue/pull/81/files#diff-a52bc111a6e6256c77df1ec50a2d35518f20caddb54fdb2292649e9d9cc8893d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AllLocoBogeys.java</strong><dd><code>统一QJ导向转向架注册名和资源路径</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/willow/train/kuayue/initial/create/AllLocoBogeys.java

<ul><li>QJ导向转向架注册名由"qj_guide_a"改为"qj_guide_bogey_a"<br> <li> 资源路径同步为"qj_guide_bogey_a"</ul>


</details>


  </td>
  <td><a href="https://github.com/KuaYueTeam/NeoKuayue/pull/81/files#diff-6d88362d44a8b098f5416c5c125a7264cc91438fb89a8dda131eedc73ea5f876">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>qj_guide_bogey_a.json</strong><dd><code>新增QJ导向转向架方块状态JSON</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/generated/locomotives/stream/qj/blockstates/track_and_bogey/qj_guide_bogey_a.json

- 新增QJ导向转向架方块状态JSON文件
- 支持不同轴向和水浸状态的模型渲染


</details>


  </td>
  <td><a href="https://github.com/KuaYueTeam/NeoKuayue/pull/81/files#diff-b2c8e63103f812475c0894c364c5920295a8be3c96fa784dc0f897e22945d3e6">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

